### PR TITLE
Add make:posttype to commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "brain/monkey": "^2.0.2",
         "satooshi/php-coveralls": "^1.0",
         "squizlabs/php_codesniffer": "^3.2",
-        "codedungeon/phpunit-result-printer": "^0.4.4"
+        "codedungeon/phpunit-result-printer": "^0.4.4",
+        "doctrine/inflector": "1.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Commands/PostTypeMake.php
+++ b/src/Commands/PostTypeMake.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rareloop\Hatchet\Commands;
+
+use Rareloop\Hatchet\Commands\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Doctrine\Common\Inflector\Inflector;
+
+class PostTypeMake extends Command
+{
+    protected $signature = 'make:posttype {name : The singular name of the post type}';
+
+    protected $description = 'Create a post type';
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $name = $input->getArgument('name');
+
+        $stub = file_get_contents(__DIR__ . '/stubs/post-type.stub');
+
+        $stub = str_replace('{{slug}}', Inflector::tableize($name), $stub);
+        $stub = str_replace('{{class_name}}', Inflector::classify($name), $stub);
+        $stub = str_replace('{{plural_name}}', Inflector::pluralize($name), $stub);
+        $stub = str_replace('{{singular_name}}', Inflector::singularize($name), $stub);
+
+        file_put_contents($this->app->basePath() . '/app/PostTypes/'.$name.'.php', $stub);
+    }
+}

--- a/src/Commands/stubs/post-type.stub
+++ b/src/Commands/stubs/post-type.stub
@@ -1,0 +1,38 @@
+<?php
+namespace App\PostTypes;
+
+use Rareloop\Lumberjack\Post;
+
+class {{class_name}} extends Post
+{
+    /**
+     * Return the key used to register the post type with WordPress
+     * First parameter of the `register_post_type` function:
+     * https://codex.wordpress.org/Function_Reference/register_post_type
+     *
+     * @return string
+     */
+    public static function getPostType()
+    {
+        return '{{slug}}';
+    }
+
+    /**
+     * Return the config to use to register the post type with WordPress
+     * Second parameter of the `register_post_type` function:
+     * https://codex.wordpress.org/Function_Reference/register_post_type
+     *
+     * @return array|null
+     */
+    protected static function getPostTypeConfig()
+    {
+        return [
+            'labels' => [
+                'name' => __('{{plural_name}}'),
+                'singular_name' => __('{{singular_name}}'),
+                'add_new_item' => __('Add New {{singular_name}}'),
+            ],
+            'public' => true,
+        ];
+    }
+}

--- a/src/Hatchet.php
+++ b/src/Hatchet.php
@@ -3,7 +3,6 @@
 namespace Rareloop\Hatchet;
 
 use DI\ContainerBuilder;
-use Rareloop\Hatchet\Commands\ControllerMake;
 use Rareloop\Lumberjack\Application;
 use Rareloop\Lumberjack\Bootstrappers\BootProviders;
 use Rareloop\Lumberjack\Bootstrappers\LoadConfiguration;
@@ -11,6 +10,9 @@ use Rareloop\Lumberjack\Bootstrappers\RegisterExceptionHandler;
 use Rareloop\Lumberjack\Bootstrappers\RegisterFacades;
 use Rareloop\Lumberjack\Bootstrappers\RegisterProviders;
 use Symfony\Component\Console\Application as ConsoleApplication;
+
+use Rareloop\Hatchet\Commands\PostTypeMake;
+use Rareloop\Hatchet\Commands\ControllerMake;
 
 class Hatchet
 {
@@ -26,6 +28,7 @@ class Hatchet
 
     protected $defaultCommands = [
         ControllerMake::class,
+        PostTypeMake::class,
     ];
 
     public function __construct(Application $app)


### PR DESCRIPTION
If you run `php hatchet make:posttype Client` it will generate the a class file for the Client post type.

Possible additions to this could be to append the `register` array in config/posttypes.php. Plus, should add some tests.

This also adds `doctrine/inflector` to the composer file for naming.